### PR TITLE
Fix: node version not update

### DIFF
--- a/main/ipc/installNode.ts
+++ b/main/ipc/installNode.ts
@@ -36,8 +36,13 @@ export default () => {
     });
 
     childProcess.on('message', ({ channel, data }: any) => {
-      if (channel === processChannel && (data.status === 'done')) {
-        killChannelChildProcess(childProcessMap, installChannel);
+      if (channel === processChannel) {
+        const { status, result } = data;
+        if (status === 'done') {
+          killChannelChildProcess(childProcessMap, installChannel);
+        } else if (status === 'success' && result && result.nodePath) {
+          process.env.PATH = `${result.nodePath.replace('/bin/node', '/bin')}${path.delimiter}${process.env.PATH}`;
+        }
       }
       sendMainWindow(channel, data);
     });

--- a/main/ipc/installNode.ts
+++ b/main/ipc/installNode.ts
@@ -41,7 +41,10 @@ export default () => {
         if (status === 'done') {
           killChannelChildProcess(childProcessMap, installChannel);
         } else if (status === 'success' && result && result.nodePath) {
-          process.env.PATH = `${result.nodePath.replace('/bin/node', '/bin')}${path.delimiter}${process.env.PATH}`;
+          // nodeEnvPath e.g: /Users/xxx/.nvm/versions/node/v14.15.0/bin/path -> Users/xxx/.nvm/versions/node/v14.15.0/bin
+          const nodeEnvPath = result.nodePath.replace('/bin/node', '/bin');
+          // process.env.PATH: /usr/local/bin -> /Users/xxx/.nvm/versions/node/v14.15.0/bin:/usr/local/bin
+          process.env.PATH = `${nodeEnvPath}${path.delimiter}${process.env.PATH}`;
         }
       }
       sendMainWindow(channel, data);

--- a/main/node/NvmManager.ts
+++ b/main/node/NvmManager.ts
@@ -58,10 +58,10 @@ class NvmManager implements INodeManager {
       });
 
       cp.on('exit', () => {
-        this.nodePath = this.getCurrentNodePath(this.std);
+        const nodePath = this.getCurrentNodePath(this.std);
         const npmVersion = this.getCurrentNpmVersion(this.std);
-
-        resolve({ nodeVersion: formattedVersion, npmVersion });
+        this.nodePath = nodePath;
+        resolve({ nodeVersion: formattedVersion, npmVersion, nodePath });
       });
     });
   };

--- a/main/packageInfo/cli/cli.ts
+++ b/main/packageInfo/cli/cli.ts
@@ -4,35 +4,36 @@ import { DEFAULT_LOCAL_PACKAGE_INFO } from '../../constants';
 import getVersionStatus from '../../utils/getVersionStatus';
 import log from '../../utils/log';
 
-function getLocalToolInfo(name: string, latestVersion: string | null) {
-  const localToolInfo = { ...DEFAULT_LOCAL_PACKAGE_INFO };
+function getLocalCliInfo(name: string, latestVersion: string | null) {
+  const localCliInfo = { ...DEFAULT_LOCAL_PACKAGE_INFO };
   // get the local path of cli
   try {
-    const toolPath = shell.which(name);
-    if (!toolPath) {
-      throw new Error(`Tool ${name} is not found.`);
+    const { stdout: cliPath } = shell.which(name);
+
+    if (!cliPath) {
+      throw new Error(`Command ${name} is not found.`);
     }
-    localToolInfo.localPath = toolPath.stdout;
+    localCliInfo.localPath = cliPath;
   } catch (error) {
     log.error(error.message);
-    return localToolInfo;
+    return localCliInfo;
   }
   // get cli version
   try {
     const { stdout: cliVersion } = execa.sync(
-      localToolInfo.localPath,
+      localCliInfo.localPath,
       ['--version'],
-      { shell: true, extendEnv: false },
+      { shell: true },
     );
     const cliVersionMatch = cliVersion.match(/(\d+(\.\d+)*)/);
-    localToolInfo.localVersion = cliVersionMatch ? cliVersionMatch[1] : cliVersion;
+    localCliInfo.localVersion = cliVersionMatch ? cliVersionMatch[1] : cliVersion;
   } catch (error) {
     log.error(`Tool ${name} version is not found. Error: ${error.message}`);
   }
   // get cli version status
-  localToolInfo.versionStatus = getVersionStatus(localToolInfo.localVersion, latestVersion);
+  localCliInfo.versionStatus = getVersionStatus(localCliInfo.localVersion, latestVersion);
 
-  return localToolInfo;
+  return localCliInfo;
 }
 
-export default getLocalToolInfo;
+export default getLocalCliInfo;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rm -rf ./dist && npm run build:renderer && npm run build:main",
     "build:renderer": "cd ./renderer && npm run build",
     "build:main": "tsc --build ./main/tsconfig.json",
-    "package": "npm run build && npm run copy:static && NPM_CONFIG_ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/ electron-builder build --mac",
+    "package": "rm -rf release && npm run build && npm run copy:static && NPM_CONFIG_ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/ electron-builder build --mac",
     "lint": "npm run eslint && npm run stylelint",
     "eslint": "eslint --ext .ts,.tsx,.js,.jsx ./",
     "eslint:fix": "npm run eslint -- --fix",


### PR DESCRIPTION
## 背景
切换版本后返回管理页面，node 版本还是旧的

## 原因
调用 `shell.which('node')` 的时候，会以 `process.env.PATH` 作为环境变量，而当前的 `process.env.PATH` 中没有新安装的 node 的 PATH
