### PR TITLE
fix: fail to debug main process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,11 @@
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
-      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
-      "windows": {
-        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
-      },
-      "program": "${workspaceRoot}/dist/index.js",
-      "args" : ["./dist"]
+      "runtimeExecutable": "npm",
+      "args": [
+        "run",
+        "start:electron"
+      ],
     }
   ]
 }

--- a/main/tsconfig.json
+++ b/main/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "./",
     "outDir": "../dist",
     "target": "es5",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
- 增加 sourcemap 配置，以使得断点能进入到未编译的 ts 文件中
- 调试主进程时运行 `npm run start:electron`