### PR TITLE
fix: install pkgs list change when switch pages

### DIFF
--- a/renderer/src/pages/Dashboard/index.tsx
+++ b/renderer/src/pages/Dashboard/index.tsx
@@ -24,6 +24,7 @@ const Dashboard = () => {
     basePackagesList,
     isInstalling,
     installPackagesList,
+    selectedInstallPackagesList,
     pkgInstallStatuses,
     pkgInstallStep,
     currentStep,
@@ -50,7 +51,7 @@ const Dashboard = () => {
     if (!packageNames.length) {
       return;
     }
-    const selectedInstallPackagesList = installPackagesList.filter((item) => {
+    const selectedPackagesList = installPackagesList.filter((item) => {
       return packageNames.includes(item.name);
     });
     const xterm = xtermManager.getTerm(TERM_ID);
@@ -58,10 +59,10 @@ const Dashboard = () => {
       xterm.clear(TERM_ID);
     }
     dispatchers.updateInstallStatus(true);
-    dispatchers.initStep(selectedInstallPackagesList);
+    dispatchers.initStep(selectedPackagesList);
     ipcRenderer
       .invoke('install-base-packages', {
-        packagesList: selectedInstallPackagesList,
+        packagesList: selectedPackagesList,
         installChannel: INSTALL_PACKAGE_CHANNEL,
         processChannel: INSTALL_PROCESS_STATUS_CHANNEL,
       })
@@ -134,7 +135,7 @@ const Dashboard = () => {
   const installStepItem = (
     <div className={styles.installStep}>
       <Step current={pkgInstallStep} direction="ver" shape="dot">
-        {installPackagesList.map((item: IBasePackage, index: number) => {
+        {selectedInstallPackagesList.map((item: IBasePackage, index: number) => {
           const { status } = pkgInstallStatuses[index] || {};
           return (
             <Step.Item

--- a/renderer/src/pages/Dashboard/index.tsx
+++ b/renderer/src/pages/Dashboard/index.tsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
     basePackagesList,
     isInstalling,
     uninstalledPackagesList,
-    selectedInstallPackagesList,
+    selectedInstalledPackagesList,
     pkgInstallStatuses,
     pkgInstallStep,
     currentStep,
@@ -135,7 +135,7 @@ const Dashboard = () => {
   const installStepItem = (
     <div className={styles.installStep}>
       <Step current={pkgInstallStep} direction="ver" shape="dot">
-        {selectedInstallPackagesList.map((item: IBasePackage, index: number) => {
+        {selectedInstalledPackagesList.map((item: IBasePackage, index: number) => {
           const { status } = pkgInstallStatuses[index] || {};
           return (
             <Step.Item

--- a/renderer/src/pages/Dashboard/index.tsx
+++ b/renderer/src/pages/Dashboard/index.tsx
@@ -23,7 +23,7 @@ const Dashboard = () => {
   const {
     basePackagesList,
     isInstalling,
-    installPackagesList,
+    uninstalledPackagesList,
     selectedInstallPackagesList,
     pkgInstallStatuses,
     pkgInstallStep,
@@ -51,7 +51,7 @@ const Dashboard = () => {
     if (!packageNames.length) {
       return;
     }
-    const selectedPackagesList = installPackagesList.filter((item) => {
+    const selectedPackagesList = uninstalledPackagesList.filter((item) => {
       return packageNames.includes(item.name);
     });
     const xterm = xtermManager.getTerm(TERM_ID);
@@ -157,7 +157,7 @@ const Dashboard = () => {
     <Loading className={styles.dashboard} visible={effectsState.getBasePackages.isLoading}>
       <PageHeader
         title="前端开发必备"
-        button={installPackagesList.length ? installButton : null}
+        button={uninstalledPackagesList.length ? installButton : null}
       />
       <main>
         {isInstalling ? (
@@ -205,7 +205,7 @@ const Dashboard = () => {
       </main>
       {visible && (
         <InstallConfirmDialog
-          packages={installPackagesList}
+          packages={uninstalledPackagesList}
           onCancel={onDialogClose}
           onOk={onDialogConfirm}
         />

--- a/renderer/src/pages/Dashboard/model.ts
+++ b/renderer/src/pages/Dashboard/model.ts
@@ -6,7 +6,7 @@ export default {
     basePackagesList: [],
     isInstalling: false,
     uninstalledPackagesList: [],
-    selectedInstallPackagesList: [],
+    selectedInstalledPackagesList: [],
     currentStep: 0,
     pkgInstallStep: 0,
     pkgInstallStatuses: [],
@@ -37,12 +37,12 @@ export default {
       prevState.pkgInstallStatuses[step].status = status;
     },
 
-    initStep(prevState, selectedInstallPackagesList: IBasePackage[]) {
+    initStep(prevState, selectedInstalledPackagesList: IBasePackage[]) {
       // skip the start step
       prevState.currentStep = 1;
       prevState.pkgInstallStep = 0;
-      prevState.pkgInstallStatuses = selectedInstallPackagesList.map((item: IBasePackage) => ({ name: item.name, status: 'wait' }));
-      prevState.selectedInstallPackagesList = selectedInstallPackagesList;
+      prevState.pkgInstallStatuses = selectedInstalledPackagesList.map((item: IBasePackage) => ({ name: item.name, status: 'wait' }));
+      prevState.selectedInstalledPackagesList = selectedInstalledPackagesList;
       prevState.installResult = [];
     },
 

--- a/renderer/src/pages/Dashboard/model.ts
+++ b/renderer/src/pages/Dashboard/model.ts
@@ -6,6 +6,7 @@ export default {
     basePackagesList: [],
     isInstalling: false,
     installPackagesList: [],
+    selectedInstallPackagesList: [],
     currentStep: 0,
     pkgInstallStep: 0,
     pkgInstallStatuses: [],
@@ -36,12 +37,12 @@ export default {
       prevState.pkgInstallStatuses[step].status = status;
     },
 
-    initStep(prevState, installPackagesList: IBasePackage[]) {
+    initStep(prevState, selectedInstallPackagesList: IBasePackage[]) {
       // skip the start step
       prevState.currentStep = 1;
       prevState.pkgInstallStep = 0;
-      prevState.pkgInstallStatuses = installPackagesList.map((item: IBasePackage) => ({ name: item.name, status: 'wait' }));
-      prevState.installPackagesList = installPackagesList;
+      prevState.pkgInstallStatuses = selectedInstallPackagesList.map((item: IBasePackage) => ({ name: item.name, status: 'wait' }));
+      prevState.selectedInstallPackagesList = selectedInstallPackagesList;
       prevState.installResult = [];
     },
 

--- a/renderer/src/pages/Dashboard/model.ts
+++ b/renderer/src/pages/Dashboard/model.ts
@@ -5,7 +5,7 @@ export default {
   state: {
     basePackagesList: [],
     isInstalling: false,
-    installPackagesList: [],
+    uninstalledPackagesList: [],
     selectedInstallPackagesList: [],
     currentStep: 0,
     pkgInstallStep: 0,
@@ -21,8 +21,8 @@ export default {
       prevState.isInstalling = isInstalling;
     },
 
-    updateInstallPackagesList(prevState, installPackagesList: IBasePackage[]) {
-      prevState.installPackagesList = installPackagesList;
+    updateUninstalledPackagesList(prevState, uninstalledPackagesList: IBasePackage[]) {
+      prevState.uninstalledPackagesList = uninstalledPackagesList;
     },
 
     updateCurrentStep(prevState, step: number) {
@@ -57,7 +57,7 @@ export default {
       const packagesList = data.filter((basePackage: IBasePackage) => {
         return basePackage.versionStatus !== 'installed';
       });
-      dispatch.dashboard.updateInstallPackagesList(packagesList);
+      dispatch.dashboard.updateUninstalledPackagesList(packagesList);
     },
   }),
 };


### PR DESCRIPTION
Fix: https://github.com/appworks-lab/toolkit/issues/5#issuecomment-851327964

原因：共用了同一个 state(uninstalledPackagesList)，页面切换的时候更新了 uninstalledPackagesList，导致新的 uninstalledPackagesList 覆盖旧的。