### PR TITLE
Fix: fail to install code to path

### DIFF
--- a/main/utils/installCommandToPath.ts
+++ b/main/utils/installCommandToPath.ts
@@ -4,7 +4,8 @@ import log from './log';
 
 /**
  * Install command to the path
- * @param target
+ * @param target the path of the command
+ * @param command the command executed in the shell
  */
 async function installCommandToPath(target: string, command: string) {
   const source = `/usr/local/bin/${command}`;
@@ -15,7 +16,7 @@ async function installCommandToPath(target: string, command: string) {
     return;
   }
 
-  // Different target, delete it first
+  // Different source, delete it first
   try {
     await fse.unlink(source);
   } catch (error) {

--- a/main/utils/installCommandToPath.ts
+++ b/main/utils/installCommandToPath.ts
@@ -1,30 +1,54 @@
+import { execSync } from 'child_process';
 import * as fse from 'fs-extra';
 import log from './log';
 
 /**
  * Install command to the path
- * @param source
+ * @param target
  */
-function installCommandToPath(source: string, command: string) {
-  const target = `/usr/local/bin/${command}`;
+async function installCommandToPath(target: string, command: string) {
+  const source = `/usr/local/bin/${command}`;
 
-  return isInstalled(target, source)
-    .then((ret) => {
-      if (ret) {
-        return Promise.resolve(null);
-      } else {
-        return fse.unlink(target)
-          .then(undefined, ignore('ENOENT', null))
-          .then(() => fse.symlink(source, target))
-          .then(() => log.info(`Link ${source} to ${target} successfully.`));
-      }
-    });
+  const installRet = await isInstalled(source, target);
+  if (installRet) {
+    log.info(`${source} has already linked to ${target}.`);
+    return;
+  }
+
+  // Different target, delete it first
+  try {
+    await fse.unlink(source);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error; // throw on any error but file not found
+    }
+  }
+
+  // link target
+  try {
+    await fse.symlink(target, source);
+  } catch (error) {
+    if (error.code !== 'EACCES' && error.code !== 'ENOENT') {
+      throw error;
+    }
+
+    try {
+      // eslint-disable-next-line
+      const linkSourceCommand = `osascript -e "do shell script \\"mkdir -p /usr/local/bin && ln -sf \'${target}\' \'${source}\'\\" with administrator privileges"`;
+      execSync(linkSourceCommand);
+    } catch (err) {
+      log.error(`Error: Unable to link ${target} to ${source}.`);
+      throw err;
+    }
+  }
+
+  log.info(`Link ${target} to ${source} successfully.`);
 }
 
-async function isInstalled(target: string, source: string) {
+async function isInstalled(source: string, target: string) {
   try {
-    const stat = await fse.lstat(target);
-    return stat.isSymbolicLink() && source === fse.realpathSync(target);
+    const stat = await fse.lstat(source);
+    return stat.isSymbolicLink() && target === fse.realpathSync(source);
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false;
@@ -32,10 +56,6 @@ async function isInstalled(target: string, source: string) {
 
     throw err;
   }
-}
-
-function ignore<T>(code: string, value: T): (err: any) => Promise<T> {
-  return (err) => (err.code === code ? Promise.resolve<T>(value) : Promise.reject<T>(err));
 }
 
 export default installCommandToPath;


### PR DESCRIPTION
背景： `fs.link`需要用户权限时，无法正确安装 code 命令到环境变量中
