### PR TITLE
Fix: stdout match

### DIFF
--- a/main/packageInstaller/CliInstaller.ts
+++ b/main/packageInstaller/CliInstaller.ts
@@ -64,7 +64,7 @@ class CliInstaller implements IPackageInstaller {
 
       cp.on('exit', () => {
         log.info(installStdout);
-        const matchRes = installStdout.match(/^(?:=> Appending nvm source string to|=> nvm source string already in) (.*)/);
+        const matchRes = installStdout.match(/(?:=> Appending nvm source string to|=> nvm source string already in) (.*)/);
         if (matchRes) {
           const nvmBashProfilePath = matchRes[1];
           executeBashConfigFile(nvmBashProfilePath);


### PR DESCRIPTION
stdout 一般是下面的内容。按照旧的正则表达式，无法匹配上正确的结果
```markdown
=> Downloading nvm from git to '/Users/luhc228/.nvm'\n\r=> Cloning into '/Users/luhc228/.nvm'...\n* (HEAD detached at FETCH_HEAD)\n  master\n=> Compressing and cleaning up git repository\n\n=> Appending nvm source string to /Users/luhc228/.profile\n=> bash_completion source string already in /Users/luhc228/.profile\nDebugger attached.\nWaiting for the debugger to disconnect...\nDebugger attached.\nWaiting for the debugger to disconnect...\n=> The Local Node is not found. It will install node v14.17.2 versio…############################### 100.0%\nComputing checksum with shasum -a 256\nChecksums matched!\nnvm is not compatible with the "npm_config_prefix" environment variable: currently set to "/Users/luhc228/.volta/tools/image/node/14.17.0"\nRun `unset npm_config_prefix` to unset it.\nFailed to install Node.js v14.17.2\n=> Close and reopen your terminal to start using nvm or run the following to use it now:\n\nexport NVM_DIR="$HOME/.nvm"\n[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"  # This loads nvm\n
```