### PR TITLE
Fix: electron not found in prod env

### DIFF
--- a/main/data/data.json
+++ b/main/data/data.json
@@ -136,7 +136,7 @@
       "isInternal": false
     }
   ],
-  "IDEExtensions": [
+  "IdeExtensions": [
     {
       "title": "AppWorks Pack",
       "name": "iceworks-team.iceworks",

--- a/main/data/data.json
+++ b/main/data/data.json
@@ -136,7 +136,7 @@
       "isInternal": false
     }
   ],
-  "IdeExtensions": [
+  "IDEExtensions": [
     {
       "title": "AppWorks Pack",
       "name": "iceworks-team.iceworks",

--- a/main/index.ts
+++ b/main/index.ts
@@ -7,7 +7,6 @@ import getPackagesData from './utils/getPackagesData';
 import { autoDownloadPackages } from './autoDownloader';
 import store, { packagesDataKey } from './store';
 import { recordDAU } from './recorder';
-import log from './utils/log';
 
 process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
 
@@ -27,13 +26,10 @@ app.whenReady()
 
     autoDownloadPackages();
 
+    recordDAU();
+
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow();
-
-      recordDAU()
-        .catch((err) => {
-          log.error(err);
-        });
     });
   });
 

--- a/main/ipc/installBasePackages.ts
+++ b/main/ipc/installBasePackages.ts
@@ -7,6 +7,7 @@ import { send as sendMainWindow } from '../window';
 import killChannelChildProcess from '../utils/killChannelChildProcess';
 import log from '../utils/log';
 import nodeCache from '../utils/nodeCache';
+import store, { packagesDataKey } from '../store';
 
 const childProcessMap = new Map();
 
@@ -23,8 +24,8 @@ export default () => {
     // fork a child process to install package
     childProcess = child_process.fork(path.join(__dirname, '..', 'packageInstaller/index'));
     childProcessMap.set(installChannel, childProcess);
-
-    childProcess.send({ packagesList, installChannel, processChannel });
+    const packagesData = store.get(packagesDataKey);
+    childProcess.send({ packagesList, packagesData, installChannel, processChannel });
 
     childProcess.on('message', ({ channel, data }: any) => {
       if (channel === processChannel) {

--- a/main/ipc/installBasePackages.ts
+++ b/main/ipc/installBasePackages.ts
@@ -24,6 +24,8 @@ export default () => {
     // fork a child process to install package
     childProcess = child_process.fork(path.join(__dirname, '..', 'packageInstaller/index'));
     childProcessMap.set(installChannel, childProcess);
+    // After packing the Electron app, the electron module which the electron-store require, couldn't be found in childProcess.
+    // For more detail, see this PR: https://github.com/appworks-lab/toolkit/pull/41
     const packagesData = store.get(packagesDataKey);
     childProcess.send({ packagesList, packagesData, installChannel, processChannel });
 

--- a/main/packageInstaller/IDEExtensionInstaller.ts
+++ b/main/packageInstaller/IDEExtensionInstaller.ts
@@ -1,20 +1,23 @@
 import * as path from 'path';
 import * as execa from 'execa';
 import isCommandInstalled from '../utils/isCommandInstalled';
-import { IPackageInfo, IPackageInstaller } from '../types';
+import { IPackageInfo, IPackageInstaller, IPackagesData, Platform } from '../types';
 import { INSTALL_COMMAND_PACKAGES, VSCODE_COMMAND_NAME, VSCODE_NAME } from '../constants';
 import writeLog from '../utils/writeLog';
-import store, { packagesDataKey } from '../store';
 import getLocalDmgInfo from '../packageInfo/dmg';
 import installCommandToPath from '../utils/installCommandToPath';
 
 class IDEExtensionInstaller implements IPackageInstaller {
   channel: string;
 
+  packagesData: IPackagesData;
+
   IDETypeProcessor: { [k: string]: Function };
 
-  constructor(channel: string) {
+  constructor(channel: string, packagesData: any) {
     this.channel = channel;
+
+    this.packagesData = packagesData;
 
     this.IDETypeProcessor = {
       VSCode: this.installVSCodeExtension,
@@ -64,9 +67,9 @@ class IDEExtensionInstaller implements IPackageInstaller {
       // try to install code command to the path
       writeLog(this.channel, 'Try to install code command to path.', true, 'info');
 
-      const { apps = [] } = store.get(packagesDataKey);
+      const { apps = [] } = this.packagesData;
 
-      const vscodeInfo = apps.find((app) => app.name === VSCODE_NAME && app.platforms.includes(process.platform));
+      const vscodeInfo = apps.find((app) => app.name === VSCODE_NAME && app.platforms.includes(process.platform as Platform));
       if (!vscodeInfo) {
         throw new Error(`${VSCODE_NAME} info was not found.`);
       }

--- a/main/types/index.ts
+++ b/main/types/index.ts
@@ -55,3 +55,9 @@ export interface INodeVersions {
   versions: string[];
   majors: Array<{ version: string; title: string }>;
 }
+
+export interface IPackagesData {
+  bases: IBasePackageInfo[];
+
+  apps: IBasePackageInfo[];
+}

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/shelljs": "^0.8.8",
     "ali-oss": "^6.15.2",
     "concurrently": "^5.1.0",
-    "electron": "12.0.9",
+    "electron": "^12.0.0",
     "electron-builder": "^22.10.5",
     "electron-notarize": "^1.0.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
问题：Electron 打包后，在子进程中找不到 electron 模块（electron-store 模块依赖 electron 模块）

原因：在 Electron 中使用子进程时，该子进程会有一个预设的环境变量 [ELECTRON_RUN_AS_NODE=1](https://github.com/electron/electron/blob/main/docs/api/environment-variables.md)，这将使得不能使用 electron 模块。详细请见 [Issue](https://github.com/electron/electron/issues/6656)

