### PR TITLE
Feat: use default shell to excute sh file

### DIFF
--- a/main/constants.ts
+++ b/main/constants.ts
@@ -28,8 +28,9 @@ export const INSTALL_COMMAND_PACKAGES = [
 ];
 export const NOT_REINSTALL_DEPENDENCIES = ['npm'];
 // bash profile
-export const PROFILE_FILES = ['.bash_profile', '.bashrc', '.zshrc'];
-export const DEFAULT_PROFILE_FILE = '.bash_profile';
+export const ZSHRC_FILE_NAME = '.zshrc';
+export const BASH_PROFILE_FILE_NAME = '.bash_profile';
+export const PROFILE_FILES = [BASH_PROFILE_FILE_NAME, '.bashrc', ZSHRC_FILE_NAME];
 // npm
 export const NPMRC_PATH = path.join(process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'], '.npmrc');
 export const NPM_REGISTRY = 'https://registry.npmjs.org/';

--- a/main/ipc/installNode.ts
+++ b/main/ipc/installNode.ts
@@ -49,7 +49,7 @@ export default () => {
         if (status === 'done') {
           killChannelChildProcess(childProcessMap, installChannel);
         } else if (status === 'success' && result && result.nodePath) {
-          // nodeEnvPath e.g: /Users/xxx/.nvm/versions/node/v14.15.0/bin/path -> Users/xxx/.nvm/versions/node/v14.15.0/bin
+          // nodeEnvPath e.g: /Users/xxx/.nvm/versions/node/v14.15.0/bin/node -> Users/xxx/.nvm/versions/node/v14.15.0/bin
           const nodeEnvPath = result.nodePath.replace('/bin/node', '/bin');
           // process.env.PATH: /usr/local/bin -> /Users/xxx/.nvm/versions/node/v14.15.0/bin:/usr/local/bin
           process.env.PATH = `${nodeEnvPath}${path.delimiter}${process.env.PATH}`;

--- a/main/node/NvmManager.ts
+++ b/main/node/NvmManager.ts
@@ -6,6 +6,7 @@ import log from '../utils/log';
 import formatNodeVersion from '../utils/formatNodeVersion';
 import { NOT_REINSTALL_DEPENDENCIES } from '../constants';
 import getNpmRegistry from '../utils/getNpmRegistry';
+import getShellName from '../utils/getShellName';
 
 class NvmManager implements INodeManager {
   channel: string;
@@ -37,7 +38,7 @@ class NvmManager implements INodeManager {
 
     return new Promise((resolve, reject) => {
       const args: string[] = [shFilePath, formattedVersion];
-      const cp = execa('sh', args);
+      const cp = execa(getShellName(), args);
 
       cp.stdout.on('data', this.listenFunc);
 

--- a/main/packageInfo/cli/node.ts
+++ b/main/packageInfo/cli/node.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as execa from 'execa';
 import { INodeVersionManagerInfo } from '../../types';
 import log from '../../utils/log';
+import getShellName from '../../utils/getShellName';
 import getLocalCliInfo from './cli';
 
 const nodeManagerInfoProcessor = {
@@ -41,7 +42,7 @@ async function getNvmInfo(): Promise<INodeVersionManagerInfo> {
   };
   const shFilePath = path.resolve(__dirname, '../../data/shells', 'is-nvm-installed.sh');
   try {
-    const { stdout } = await execa('sh', [shFilePath]);
+    const { stdout } = await execa(getShellName(), [shFilePath]);
     if (stdout === 'nvm') {
       nvmInfo.managerVersionStatus = 'installed';
     }

--- a/main/packageInstaller/CliInstaller.ts
+++ b/main/packageInstaller/CliInstaller.ts
@@ -4,6 +4,7 @@ import { IPackageInfo, IPackageInstaller } from '../types';
 import log from '../utils/log';
 import ensureProfileExists from '../utils/ensureProfileExists';
 import writeLog from '../utils/writeLog';
+import getShellName from '../utils/getShellName';
 
 class CliInstaller implements IPackageInstaller {
   channel: string;
@@ -53,7 +54,7 @@ class CliInstaller implements IPackageInstaller {
         process.send({ channel: this.channel, data: { chunk, ln: false } });
       };
 
-      const cp = execa('sh', [shPath]);
+      const cp = execa(getShellName(), [shPath]);
 
       cp.stdout.on('data', listenFunc);
 

--- a/main/utils/ensureProfileExists.ts
+++ b/main/utils/ensureProfileExists.ts
@@ -1,8 +1,9 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as shell from 'shelljs';
-import { PROFILE_FILES, DEFAULT_PROFILE_FILE } from '../constants';
+import { PROFILE_FILES, BASH_PROFILE_FILE_NAME, ZSHRC_FILE_NAME } from '../constants';
 import log from './log';
+import getShellName from './getShellName';
 
 /**
  * Ensure profile file exists. Otherwise, create ~/.bash_profile file by default.
@@ -12,9 +13,10 @@ function ensureProfileExists() {
     return fse.pathExistsSync(path.join(process.env.HOME, bashConfigFile));
   });
   if (!isProfileExists) {
-    const defaultBashConfigFilePath = path.join(process.env.HOME, DEFAULT_PROFILE_FILE);
-    log.info(`${PROFILE_FILES.join(',')} were not found. Create ${defaultBashConfigFilePath}.`);
-    shell.touch(defaultBashConfigFilePath);
+    const shellName = getShellName();
+    const profilePath = path.join(process.env.HOME, shellName === 'zsh' ? ZSHRC_FILE_NAME : BASH_PROFILE_FILE_NAME);
+    log.info(`${PROFILE_FILES.join(',')} were not found. Create ${profilePath}.`);
+    shell.touch(profilePath);
   }
 }
 

--- a/main/utils/getShellName.ts
+++ b/main/utils/getShellName.ts
@@ -1,0 +1,10 @@
+/**
+ * get current shell name. e.g. zsh/sh/bash
+ */
+function getShellName(): string {
+  const shellPath = process.env.SHELL;
+  const splitPaths = shellPath.split('/');
+  return splitPaths[splitPaths.length - 1];
+}
+
+export default getShellName;


### PR DESCRIPTION
### 背景

目前，安装 nvm 时会调用 shell 脚本 `sh install.sh` (install.sh 是来自于 https://github.com/nvm-sh/nvm)。假如现在同时存在 .bash_profile 和 .zshrc 时并且默认的 shell 是 /bin/zsh 时，会把 nvm 的配置写到 .bash_profile 中，但是期望的是 .zshrc。

### 解决

需要先获取当前的 shell，然后再去调用执行 `install.sh`
```js
function getShellName(): string {
  const shellPath = process.env.SHELL;
  const splitPaths = shellPath.split('/');
  return splitPaths[splitPaths.length - 1];
}

getShellName();        // zsh or sh or bash
```