### PR TITLE
feat: add base packages info cache

### DIFF
--- a/renderer/src/pages/Dashboard/index.tsx
+++ b/renderer/src/pages/Dashboard/index.tsx
@@ -78,7 +78,7 @@ const Dashboard = () => {
 
   function goBack() {
     dispatchers.updateInstallStatus(false);
-    dispatchers.getBasePackages();
+    dispatchers.getBasePackages(true);
   }
 
   async function handleCancelInstall() {

--- a/renderer/src/pages/Dashboard/model.ts
+++ b/renderer/src/pages/Dashboard/model.ts
@@ -51,8 +51,8 @@ export default {
     },
   },
   effects: (dispatch) => ({
-    async getBasePackages() {
-      const data = await ipcRenderer.invoke('get-base-packages-info');
+    async getBasePackages(force = false) {
+      const data = await ipcRenderer.invoke('get-base-packages-info', force);
       dispatch.dashboard.updateBasePackagesList(data);
       const packagesList = data.filter((basePackage: PackageInfo) => {
         return basePackage.versionStatus !== 'installed';


### PR DESCRIPTION
增加首页的前端必备工具信息的缓存，避免每次进入页面都重新获取